### PR TITLE
Bump operator and component versions to 3.6.0 and remove the RouterAd…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,8 @@ OS = $(shell uname -s | tr '[:upper:]' '[:lower:]')
 
 VERSION = $(shell cat PROJECT | grep "version:" | sed "s/^version: //g")
 PREFIX = github.com/datasance/iofog-operator/v3/internal/util
-LDFLAGS += -X $(PREFIX).routerAdaptorTag=3.5.2
-LDFLAGS += -X $(PREFIX).routerTag=3.5.2
-LDFLAGS += -X $(PREFIX).controllerTag=3.5.10
+LDFLAGS += -X $(PREFIX).routerTag=3.6.0
+LDFLAGS += -X $(PREFIX).controllerTag=3.6.0
 LDFLAGS += -X $(PREFIX).repo=ghcr.io/datasance
 
 export CGO_ENABLED ?= 0
@@ -15,7 +14,7 @@ endif
 
 # Image URL to use all building/pushing image targets
 REGISTRY ?= ghcr.io/datasance
-VERSION_TAG ?= 3.5.4
+VERSION_TAG ?= 3.6.0
 IMG ?= operator:$(VERSION_TAG)
 BUNDLE_IMG ?= operator-bundle:$(VERSION_TAG)
 # Produce CRDs that work back to Kubernetes 1.11 (no version conversion)

--- a/apis/controlplanes/v3/controlplane_types.go
+++ b/apis/controlplanes/v3/controlplane_types.go
@@ -76,10 +76,9 @@ type Service struct {
 }
 
 type Images struct {
-	PullSecret    string `json:"pullSecret,omitempty"`
-	Controller    string `json:"controller,omitempty"`
-	Router        string `json:"router,omitempty"`
-	RouterAdaptor string `json:"routerAdaptor,omitempty"`
+	PullSecret string `json:"pullSecret,omitempty"`
+	Controller string `json:"controller,omitempty"`
+	Router     string `json:"router,omitempty"`
 }
 
 type Auth struct {

--- a/bundle/manifests/datasance.com_controlplanes.yaml
+++ b/bundle/manifests/datasance.com_controlplanes.yaml
@@ -117,8 +117,6 @@ spec:
                 properties:
                   controller:
                     type: string
-                  routerAdaptor:
-                    type: string
                   pullSecret:
                     type: string
                   router:

--- a/bundle/manifests/iofog-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/iofog-operator.clusterserviceversion.yaml
@@ -35,7 +35,6 @@ metadata:
             "images": {
               "pullSecret": "pullsecret",
               "controller": "ghcr.io/datasance/controller@sha256:a9df302208e61cff20240365fd00ae319ebeadb79ca5f0fd831e3b4ebe55041b",
-              "routerAdaptor": "ghcr.io/datasance/router-adaptor@sha256:276dbed0c8ef4f5b03fdf29d5c863b6f3efcae50444ce8123220c5673272860f",
               "router": "ghcr.io/datasance/router@sha256:82657fc8f39d33d8ef0161cf27d705cbdc0a97dca07b22a5fe78fd4213ef0d31"
             },
             "services": {
@@ -215,11 +214,6 @@ spec:
           - description: Image for the Control Plane controller component
             displayName: Controller Image
             path: images.controller
-            x-descriptors:
-              - urn:alm:descriptor:com.tectonic.ui:text
-          - description: Image for the RouterAdaptor component
-            displayName: RouterAdaptor Image
-            path: images.routerAdaptor
             x-descriptors:
               - urn:alm:descriptor:com.tectonic.ui:text
           - description: Image for the Router component
@@ -524,6 +518,4 @@ spec:
       image: ghcr.io/datasance/controller@sha256:a9df302208e61cff20240365fd00ae319ebeadb79ca5f0fd831e3b4ebe55041b
     - name: router
       image: ghcr.io/datasance/router@sha256:82657fc8f39d33d8ef0161cf27d705cbdc0a97dca07b22a5fe78fd4213ef0d31
-    - name: routerAdaptor
-      image: ghcr.io/datasance/router-adaptor@sha256:276dbed0c8ef4f5b03fdf29d5c863b6f3efcae50444ce8123220c5673272860f 
   version: 3.4.13

--- a/config/cr/controlplane.yaml
+++ b/config/cr/controlplane.yaml
@@ -30,7 +30,6 @@ spec:
   images:
     pullSecret: 
     controller:
-    routerAdaptor: 
     router: 
   services:
     controller:
@@ -48,8 +47,6 @@ spec:
     https: # true or false  ..default is false
     secretName: #name of secret it has to be same with the one that defined in the controller ingress struct
     logLevel:
-  # router:
-  #   ha: # true or false ..default is false. When true, creates a second router deployment (router-2) for high availability
   ingresses:
     controller:
       annotations:

--- a/config/crd/bases/datasance.com_applications.yaml
+++ b/config/crd/bases/datasance.com_applications.yaml
@@ -76,6 +76,14 @@ spec:
                               type: integer
                             dockerUrl:
                               type: string
+                            edgeGuardFrequency:
+                              type: number
+                            gpsDevice:
+                              type: string
+                            gpsMode:
+                              type: string
+                            gpsScanFrequency:
+                              type: number
                             logDirectory:
                               type: string
                             logFileCount:
@@ -132,6 +140,8 @@ spec:
                           items:
                             type: string
                           type: array
+                        cpuSetCpus:
+                          type: string
                         env:
                           items:
                             properties:
@@ -158,6 +168,42 @@ spec:
                                 type: string
                             type: object
                           type: array
+                        healthCheck:
+                          description: MicroserviceHealthCheck contains information
+                            about the health check of a microservice
+                          properties:
+                            interval:
+                              format: int64
+                              type: integer
+                            retries:
+                              type: integer
+                            startInterval:
+                              format: int64
+                              type: integer
+                            startPeriod:
+                              format: int64
+                              type: integer
+                            test:
+                              items:
+                                type: string
+                              type: array
+                            timeout:
+                              format: int64
+                              type: integer
+                          required:
+                          - test
+                          type: object
+                        hostNetworkMode:
+                          type: boolean
+                        ipcMode:
+                          type: string
+                        isPrivileged:
+                          type: boolean
+                        memoryLimit:
+                          format: int64
+                          type: integer
+                        pidMode:
+                          type: string
                         platform:
                           type: string
                         ports:
@@ -176,8 +222,6 @@ spec:
                             - internal
                             type: object
                           type: array
-                        rootHostAccess:
-                          type: boolean
                         runAsUser:
                           type: string
                         runtime:
@@ -200,11 +244,24 @@ spec:
                             type: object
                           type: array
                       required:
+                      - hostNetworkMode
+                      - isPrivileged
                       - ports
-                      - rootHostAccess
                       type: object
                     created:
                       type: string
+                    execStatus:
+                      description: MicroserviceExecStatusInfo contains information
+                        about the exec status of a microservice
+                      properties:
+                        execSessionId:
+                          type: string
+                        status:
+                          type: string
+                      required:
+                      - execSessionId
+                      - status
+                      type: object
                     flow:
                       type: string
                     images:
@@ -240,12 +297,58 @@ spec:
                       type: string
                     rebuild:
                       type: boolean
+                    schedule:
+                      type: integer
+                    status:
+                      description: MicroserviceStatusInfo contains information about
+                        the status of a microservice
+                      properties:
+                        containerId:
+                          type: string
+                        cpuUsage:
+                          type: number
+                        errorMessage:
+                          type: string
+                        execSessionIds:
+                          items:
+                            type: string
+                          type: array
+                        healthStatus:
+                          type: string
+                        ipAddress:
+                          type: string
+                        memoryUsage:
+                          type: number
+                        operatingDuration:
+                          format: int64
+                          type: integer
+                        percentage:
+                          type: number
+                        startTime:
+                          format: int64
+                          type: integer
+                        status:
+                          type: string
+                      required:
+                      - containerId
+                      - cpuUsage
+                      - errorMessage
+                      - execSessionIds
+                      - healthStatus
+                      - ipAddress
+                      - memoryUsage
+                      - operatingDuration
+                      - percentage
+                      - startTime
+                      - status
+                      type: object
                     uuid:
                       type: string
                   required:
                   - agent
                   - config
                   - name
+                  - schedule
                   - uuid
                   type: object
                 type: array

--- a/config/crd/bases/datasance.com_controlplanes.yaml
+++ b/config/crd/bases/datasance.com_controlplanes.yaml
@@ -78,10 +78,10 @@ spec:
                     type: integer
                   ecnViewerUrl:
                     type: string
-                  logLevel:
-                    type: string
                   https:
                     type: boolean
+                  logLevel:
+                    type: string
                   pidBaseDir:
                     type: string
                   secretName:
@@ -90,6 +90,8 @@ spec:
               database:
                 description: Database for ioFog Controller
                 properties:
+                  ca:
+                    type: string
                   databaseName:
                     type: string
                   host:
@@ -100,6 +102,8 @@ spec:
                     type: integer
                   provider:
                     type: string
+                  ssl:
+                    type: boolean
                   user:
                     type: string
                 required:
@@ -110,6 +114,21 @@ spec:
                 - provider
                 - user
                 type: object
+              events:
+                description: |-
+                  // Router contains runtime configuration for ioFog Router
+                  Router Router `json:"router,omitempty"`
+                  Events contains runtime configuration for ioFog Controller events
+                properties:
+                  auditEnabled:
+                    type: boolean
+                  captureIpAddress:
+                    type: boolean
+                  cleanupInterval:
+                    type: integer
+                  retentionDays:
+                    type: integer
+                type: object
               images:
                 description: Images specifies which containers to run for each component
                   of the ControlPlane
@@ -119,8 +138,6 @@ spec:
                   pullSecret:
                     type: string
                   router:
-                    type: string
-                  routerAdaptor:
                     type: string
                 type: object
               ingresses:
@@ -274,9 +291,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/config/manifests/bases/iofog-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/iofog-operator.clusterserviceversion.yaml
@@ -34,7 +34,6 @@ metadata:
             "images": {
               "pullSecret": null,
               "controller": null,
-              "routerAdaptor": null,
               "router": null
             },
             "services": {

--- a/controllers/controlplanes/k8s.go
+++ b/controllers/controlplanes/k8s.go
@@ -60,7 +60,7 @@ func (r *ControlPlaneReconciler) restartPodsForDeployment(ctx context.Context, d
 }
 
 func (r *ControlPlaneReconciler) createDeployment(ctx context.Context, ms *microservice) error {
-	dep := newDeployment(r.cp.ObjectMeta.Namespace, ms)
+	dep := newDeployment(r.cp.ObjectMeta.Namespace, r.cp.Name, ms)
 	// Set ControlPlane instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&r.cp, dep, r.Scheme); err != nil {
 		return err
@@ -120,6 +120,7 @@ func (r *ControlPlaneReconciler) createPersistentVolumeClaims(ctx context.Contex
 
 		pvc.ObjectMeta.Name = ms.volumes[i].Name
 		pvc.ObjectMeta.Namespace = r.cp.Namespace
+		pvc.ObjectMeta.Labels = getStandardLabels(getComponentFromMicroservice(ms), r.cp.Name)
 		// Set ControlPlane instance as the owner and controller
 		if err := controllerutil.SetControllerReference(&r.cp, &pvc, r.Scheme); err != nil {
 			return err
@@ -161,8 +162,10 @@ func (r *ControlPlaneReconciler) createOrUpdateSecrets(ctx context.Context, ms *
 		}
 	}()
 
+	stdLabels := getStandardLabels(getComponentFromMicroservice(ms), r.cp.Name)
 	for i := range ms.secrets {
 		secret := &ms.secrets[i]
+		secret.Labels = mergeLabels(stdLabels, secret.Labels)
 		r.log.Info(fmt.Sprintf("Creating secret %s", secret.ObjectMeta.Name))
 		// Set ControlPlane instance as the owner and controller
 		r.log.Info(fmt.Sprintf("Setting owner reference for secret %s", secret.ObjectMeta.Name))
@@ -216,7 +219,7 @@ func (r *ControlPlaneReconciler) createOrUpdateSecrets(ctx context.Context, ms *
 }
 
 func (r *ControlPlaneReconciler) createService(ctx context.Context, ms *microservice) error {
-	svcs := newServices(r.cp.ObjectMeta.Namespace, ms)
+	svcs := newServices(r.cp.ObjectMeta.Namespace, r.cp.Name, ms)
 	for _, svc := range svcs {
 		// Set ControlPlane instance as the owner and controller
 		if err := controllerutil.SetControllerReference(&r.cp, svc, r.Scheme); err != nil {
@@ -249,7 +252,7 @@ func (r *ControlPlaneReconciler) createService(ctx context.Context, ms *microser
 }
 
 func (r *ControlPlaneReconciler) createIngress(ctx context.Context, cfg *controllerIngressConfig) error {
-	ingress := newControllerIngress(r.cp.ObjectMeta.Namespace, cfg)
+	ingress := newControllerIngress(r.cp.ObjectMeta.Namespace, r.cp.Name, cfg)
 
 	// Set ControlPlane instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&r.cp, ingress, r.Scheme); err != nil {
@@ -285,7 +288,7 @@ func (r *ControlPlaneReconciler) createIngress(ctx context.Context, cfg *control
 }
 
 func (r *ControlPlaneReconciler) createServiceAccount(ctx context.Context, ms *microservice) error {
-	svcAcc := newServiceAccount(r.cp.ObjectMeta.Namespace, ms)
+	svcAcc := newServiceAccount(r.cp.ObjectMeta.Namespace, r.cp.Name, ms)
 
 	// Set image pull secret for the service account
 	if ms.imagePullSecret != "" {
@@ -338,7 +341,7 @@ func (r *ControlPlaneReconciler) createServiceAccount(ctx context.Context, ms *m
 }
 
 func (r *ControlPlaneReconciler) createRole(ctx context.Context, ms *microservice) error { //nolint:dupl
-	role := newRole(r.cp.ObjectMeta.Namespace, ms)
+	role := newRole(r.cp.ObjectMeta.Namespace, r.cp.Name, ms)
 
 	// Set ControlPlane instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&r.cp, role, r.Scheme); err != nil {
@@ -370,7 +373,7 @@ func (r *ControlPlaneReconciler) createRole(ctx context.Context, ms *microservic
 }
 
 func (r *ControlPlaneReconciler) createRoleBinding(ctx context.Context, ms *microservice) error { //nolint:dupl
-	crb := newRoleBinding(r.cp.ObjectMeta.Namespace, ms)
+	crb := newRoleBinding(r.cp.ObjectMeta.Namespace, r.cp.Name, ms)
 
 	// Set ControlPlane instance as the owner and controller
 	if err := controllerutil.SetControllerReference(&r.cp, crb, r.Scheme); err != nil {
@@ -610,7 +613,7 @@ func mergeConfigs(existingConfig, newConfig string) (string, error) {
 }
 
 func (r *ControlPlaneReconciler) createConfigMap(ctx context.Context) error {
-	configMap := newRouterConfigMap(r.cp.ObjectMeta.Namespace)
+	configMap := newRouterConfigMap(r.cp.ObjectMeta.Namespace, r.cp.Name)
 
 	// Set owner reference
 	if err := controllerutil.SetControllerReference(&r.cp, configMap, r.Scheme); err != nil {
@@ -635,8 +638,9 @@ func (r *ControlPlaneReconciler) createConfigMap(ctx context.Context) error {
 		return fmt.Errorf("failed to merge configs: %w", err)
 	}
 
-	// Update ConfigMap with merged configuration
+	// Update ConfigMap with merged configuration and standard labels
 	existingConfigMap.Data["skrouterd.json"] = mergedConfig
+	existingConfigMap.Labels = mergeLabels(configMap.Labels, existingConfigMap.Labels)
 	return r.Client.Update(ctx, existingConfigMap)
 }
 

--- a/controllers/controlplanes/microservices.go
+++ b/controllers/controlplanes/microservices.go
@@ -93,6 +93,7 @@ type container struct {
 }
 
 type controllerMicroserviceConfig struct {
+	controllerName     string
 	replicas           int32
 	image              string
 	imagePullSecret    string
@@ -105,7 +106,6 @@ type controllerMicroserviceConfig struct {
 	auth               *cpv3.Auth
 	db                 *cpv3.Database
 	events             *cpv3.Events
-	routerAdaptorImage string
 	routerImage        string
 	ecn                string
 	pidBaseDir         string
@@ -429,6 +429,10 @@ func newControllerMicroservice(namespace string, cfg *controllerMicroserviceConf
 						Value: "Kubernetes",
 					},
 					{
+						Name:  "CONTROLLER_NAME",
+						Value: cfg.controllerName,
+					},
+					{
 						Name:  "CONTROLLER_NAMESPACE",
 						Value: namespace,
 					},
@@ -571,11 +575,9 @@ func newControllerMicroservice(namespace string, cfg *controllerMicroserviceConf
 
 type routerMicroserviceConfig struct {
 	image              string
-	adaptorImage       string
 	imagePullSecret    string
 	serviceType        string
 	serviceAnnotations map[string]string
-	volumeMountPath    string
 	siteCA             string
 	localCA            string
 	siteSecret         string
@@ -586,10 +588,6 @@ type routerMicroserviceConfig struct {
 func filterRouterConfig(cfg routerMicroserviceConfig) routerMicroserviceConfig {
 	if cfg.image == "" {
 		cfg.image = util.GetRouterImage()
-	}
-
-	if cfg.adaptorImage == "" {
-		cfg.adaptorImage = util.GetRouterAdaptorImage()
 	}
 
 	if cfg.serviceType == "" {
@@ -680,7 +678,7 @@ func newRouterMicroservice(cfg routerMicroserviceConfig) *microservice {
 				Resources: []string{"pods"},
 			},
 			{
-				Verbs:     []string{"get", "list", "watch", "create", "update", "patch", "delete"},
+				Verbs:     []string{"get", "list", "watch"},
 				APIGroups: []string{""},
 				Resources: []string{"configmaps"},
 			},
@@ -707,31 +705,29 @@ func newRouterMicroservice(cfg routerMicroserviceConfig) *microservice {
 		},
 		volumes: []corev1.Volume{
 			{
-				Name: "pot-router-certs",
+				Name: "pot-router-config",
 				VolumeSource: corev1.VolumeSource{
-					EmptyDir: &corev1.EmptyDirVolumeSource{},
-				},
-			},
-		},
-		initContainers: []container{
-			{
-				name:            "router-config-init",
-				image:           cfg.adaptorImage,
-				imagePullPolicy: "Always",
-				command: []string{
-					"/app/kube-adaptor",
-					"-init",
-				},
-				env: []corev1.EnvVar{
-					{
-						Name:  "SKUPPER_ROUTER_CONFIG",
-						Value: "pot-router",
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "pot-router"},
+						Items: []corev1.KeyToPath{
+							{Key: "skrouterd.json", Path: "skrouterd.json"},
+						},
 					},
 				},
-				volumeMounts: []corev1.VolumeMount{
-					{
-						Name:      "pot-router-certs",
-						MountPath: "/etc/skupper-router-certs",
+			},
+			{
+				Name: "pot-router-site-server",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "pot-router-site-server",
+					},
+				},
+			},
+			{
+				Name: "pot-router-local-server",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "pot-router-local-server",
 					},
 				},
 			},
@@ -742,7 +738,7 @@ func newRouterMicroservice(cfg routerMicroserviceConfig) *microservice {
 				image:           cfg.image,
 				imagePullPolicy: "Always",
 				command: []string{
-					"/home/skrouterd/bin/launch.sh",
+					"/home/skrouterd/bin/router",
 				},
 				ports: []corev1.ContainerPort{
 					{
@@ -805,15 +801,23 @@ func newRouterMicroservice(cfg routerMicroserviceConfig) *microservice {
 					},
 					{
 						Name:  "QDROUTERD_CONF",
-						Value: "/etc/skupper-router-certs/skrouterd.json",
+						Value: "/tmp/skrouterd.json",
 					},
 					{
 						Name:  "QDROUTERD_CONF_TYPE",
 						Value: "json",
 					},
 					{
+						Name:  "SSL_PROFILE_PATH",
+						Value: "/etc/skupper-router-certs",
+					},
+					{
 						Name:  "SKUPPER_SITE_ID",
 						Value: "default-router",
+					},
+					{
+						Name:  "SKUPPER_PLATFORM",
+						Value: "kubernetes",
 					},
 					{
 						Name: "POD_NAMESPACE",
@@ -834,63 +838,16 @@ func newRouterMicroservice(cfg routerMicroserviceConfig) *microservice {
 				},
 				volumeMounts: []corev1.VolumeMount{
 					{
-						Name:      "pot-router-certs",
-						MountPath: cfg.volumeMountPath,
-					},
-				},
-			},
-			{
-				name:            "router-adaptor",
-				image:           cfg.adaptorImage,
-				imagePullPolicy: "Always",
-				env: []corev1.EnvVar{
-					{
-						Name: "SKUPPER_NAMESPACE",
-						ValueFrom: &corev1.EnvVarSource{
-							FieldRef: &corev1.ObjectFieldSelector{
-								FieldPath: "metadata.namespace",
-							},
-						},
+						Name:      "pot-router-config",
+						MountPath: "/tmp",
 					},
 					{
-						Name: "SKUPPER_NAME",
-						ValueFrom: &corev1.EnvVarSource{
-							FieldRef: &corev1.ObjectFieldSelector{
-								FieldPath: "metadata.namespace",
-							},
-						},
+						Name:      "pot-router-site-server",
+						MountPath: "/etc/skupper-router-certs/pot-router-site-server",
 					},
 					{
-						Name:  "SKUPPER_SITE_ID",
-						Value: "default-router",
-					},
-					{
-						Name:  "SKUPPER_ROUTER_CONFIG",
-						Value: "pot-router",
-					},
-					{
-						Name:  "SKUPPER_ROUTER_DEPLOYMENT",
-						Value: "router",
-					},
-				},
-				readinessProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Port:   intstr.FromInt(9191),
-							Path:   "/healthz",
-							Scheme: corev1.URISchemeHTTP,
-						},
-					},
-					InitialDelaySeconds: 1,
-					TimeoutSeconds:      1,
-					PeriodSeconds:       10,
-					FailureThreshold:    3,
-					SuccessThreshold:    1,
-				},
-				volumeMounts: []corev1.VolumeMount{
-					{
-						Name:      "pot-router-certs",
-						MountPath: "/etc/skupper-router-certs",
+						Name:      "pot-router-local-server",
+						MountPath: "/etc/skupper-router-certs/pot-router-local-server",
 					},
 				},
 			},
@@ -950,29 +907,29 @@ func newRouterMicroserviceWithName(cfg routerMicroserviceConfig, name string) *m
 		},
 		volumes: []corev1.Volume{
 			{
-				Name: "pot-router-certs",
+				Name: "pot-router-config",
 				VolumeSource: corev1.VolumeSource{
-					Secret: &corev1.SecretVolumeSource{
-						SecretName: "pot-router-certs",
+					ConfigMap: &corev1.ConfigMapVolumeSource{
+						LocalObjectReference: corev1.LocalObjectReference{Name: "pot-router"},
+						Items: []corev1.KeyToPath{
+							{Key: "skrouterd.json", Path: "skrouterd.json"},
+						},
 					},
 				},
 			},
-		},
-		initContainers: []container{
 			{
-				name:            "router-config-init",
-				image:           cfg.adaptorImage,
-				imagePullPolicy: "Always",
-				env: []corev1.EnvVar{
-					{
-						Name:  "SKUPPER_ROUTER_CONFIG",
-						Value: "pot-router",
+				Name: "pot-router-site-server",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "pot-router-site-server",
 					},
 				},
-				volumeMounts: []corev1.VolumeMount{
-					{
-						Name:      "pot-router-certs",
-						MountPath: "/etc/skupper-router-certs",
+			},
+			{
+				Name: "pot-router-local-server",
+				VolumeSource: corev1.VolumeSource{
+					Secret: &corev1.SecretVolumeSource{
+						SecretName: "pot-router-local-server",
 					},
 				},
 			},
@@ -1046,11 +1003,15 @@ func newRouterMicroserviceWithName(cfg routerMicroserviceConfig, name string) *m
 					},
 					{
 						Name:  "QDROUTERD_CONF",
-						Value: "/etc/skupper-router-certs/skrouterd.json",
+						Value: "/tmp/skrouterd.json",
 					},
 					{
 						Name:  "QDROUTERD_CONF_TYPE",
 						Value: "json",
+					},
+					{
+						Name:  "SSL_PROFILE_PATH",
+						Value: "/etc/skupper-router-certs",
 					},
 					{
 						Name:  "SKUPPER_SITE_ID",
@@ -1060,66 +1021,23 @@ func newRouterMicroserviceWithName(cfg routerMicroserviceConfig, name string) *m
 						Name:  "SKUPPER_SITE_NAME",
 						Value: "default-router",
 					},
+					{
+						Name:  "SKUPPER_PLATFORM",
+						Value: "kubernetes",
+					},
 				},
 				volumeMounts: []corev1.VolumeMount{
 					{
-						Name:      "pot-router-certs",
-						MountPath: cfg.volumeMountPath,
-					},
-				},
-			},
-			{
-				name:            "router-adaptor",
-				image:           cfg.adaptorImage,
-				imagePullPolicy: "Always",
-				env: []corev1.EnvVar{
-					{
-						Name: "SKUPPER_NAMESPACE",
-						ValueFrom: &corev1.EnvVarSource{
-							FieldRef: &corev1.ObjectFieldSelector{
-								FieldPath: "metadata.namespace",
-							},
-						},
+						Name:      "pot-router-config",
+						MountPath: "/tmp",
 					},
 					{
-						Name: "SKUPPER_NAME",
-						ValueFrom: &corev1.EnvVarSource{
-							FieldRef: &corev1.ObjectFieldSelector{
-								FieldPath: "metadata.namespace",
-							},
-						},
+						Name:      "pot-router-site-server",
+						MountPath: "/etc/skupper-router-certs/pot-router-site-server",
 					},
 					{
-						Name:  "SKUPPER_SITE_ID",
-						Value: "default-router",
-					},
-					{
-						Name:  "SKUPPER_ROUTER_CONFIG",
-						Value: "pot-router",
-					},
-					{
-						Name:  "SKUPPER_ROUTER_DEPLOYMENT",
-						Value: "router",
-					},
-				},
-				readinessProbe: &corev1.Probe{
-					ProbeHandler: corev1.ProbeHandler{
-						HTTPGet: &corev1.HTTPGetAction{
-							Port:   intstr.FromInt(9191),
-							Path:   "/healthz",
-							Scheme: corev1.URISchemeHTTP,
-						},
-					},
-					InitialDelaySeconds: 1,
-					TimeoutSeconds:      1,
-					PeriodSeconds:       10,
-					FailureThreshold:    3,
-					SuccessThreshold:    1,
-				},
-				volumeMounts: []corev1.VolumeMount{
-					{
-						Name:      "pot-router-certs",
-						MountPath: "/etc/skupper-router-certs",
+						Name:      "pot-router-local-server",
+						MountPath: "/etc/skupper-router-certs/pot-router-local-server",
 					},
 				},
 			},

--- a/controllers/controlplanes/reconcile.go
+++ b/controllers/controlplanes/reconcile.go
@@ -43,10 +43,12 @@ func reconcileRoutine(ctx context.Context, recon func(context.Context) op.Reconc
 }
 
 func (r *ControlPlaneReconciler) reconcileDBCredentialsSecret(ctx context.Context, ms *microservice) (shouldRestartPod bool, err error) {
+	stdLabels := getStandardLabels("controller", r.cp.Name)
 	for i := range ms.secrets {
 		secret := &ms.secrets[i]
 
 		if secret.Name == controllerDBCredentialsSecretName {
+			secret.Labels = mergeLabels(stdLabels, secret.Labels)
 			found := &corev1.Secret{}
 
 			err := r.Client.Get(ctx, types.NamespacedName{Name: secret.Name, Namespace: secret.Namespace}, found)
@@ -79,10 +81,10 @@ func (r *ControlPlaneReconciler) reconcileDBCredentialsSecret(ctx context.Contex
 func (r *ControlPlaneReconciler) reconcileIofogController(ctx context.Context) op.Reconciliation {
 	// Configure Controller
 	config := &controllerMicroserviceConfig{
+		controllerName:     r.cp.Name,
 		replicas:           r.cp.Spec.Replicas.Controller,
 		image:              r.cp.Spec.Images.Controller,
 		imagePullSecret:    r.cp.Spec.Images.PullSecret,
-		routerAdaptorImage: r.cp.Spec.Images.RouterAdaptor,
 		routerImage:        r.cp.Spec.Images.Router,
 		db:                 &r.cp.Spec.Database,
 		auth:               &r.cp.Spec.Auth,
@@ -334,9 +336,6 @@ func (r *ControlPlaneReconciler) ImportCertificates(iofogClient *iofogclient.Cli
 }
 
 func (r *ControlPlaneReconciler) reconcileRouter(ctx context.Context) op.Reconciliation {
-	// Configure
-	volumeMountPath := "/etc/skupper-router-certs"
-
 	// Check if HA is enabled (default to false if not specified)
 	haEnabled := false
 	// if r.cp.Spec.Router.HA != nil {
@@ -345,11 +344,9 @@ func (r *ControlPlaneReconciler) reconcileRouter(ctx context.Context) op.Reconci
 
 	routerMicroservices := newRouterMicroservices(routerMicroserviceConfig{
 		image:              r.cp.Spec.Images.Router,
-		adaptorImage:       r.cp.Spec.Images.RouterAdaptor,
 		imagePullSecret:    r.cp.Spec.Images.PullSecret,
 		serviceType:        r.cp.Spec.Services.Router.Type,
 		serviceAnnotations: r.cp.Spec.Services.Router.Annotations,
-		volumeMountPath:    volumeMountPath,
 		ha:                 haEnabled,
 	})
 
@@ -497,10 +494,12 @@ func (r *ControlPlaneReconciler) createRouterSecrets(namespace string, ms *micro
 	var siteCA, localCA corev1.Secret
 
 	// Generate CA certificates if they don't exist
+	routerLabels := getStandardLabels("router", r.cp.Name)
 	if !siteCAExists {
 		r.log.Info(fmt.Sprintf("Generating site CA Secret for Controlplane %s", r.cp.Name))
 		siteCA = util.GenerateSecret(SiteCaSecret, SiteCaSecret, SiteCaSecret, 0, nil)
 		siteCA.Namespace = namespace
+		siteCA.Labels = routerLabels
 		ms.secrets = append(ms.secrets, siteCA)
 	} else {
 		siteCA = *existingSiteCA
@@ -510,6 +509,7 @@ func (r *ControlPlaneReconciler) createRouterSecrets(namespace string, ms *micro
 		r.log.Info(fmt.Sprintf("Generating local CA Secret for Controlplane %s", r.cp.Name))
 		localCA = util.GenerateSecret(LocalCaSecret, LocalCaSecret, LocalCaSecret, 0, nil)
 		localCA.Namespace = namespace
+		localCA.Labels = routerLabels
 		ms.secrets = append(ms.secrets, localCA)
 	} else {
 		localCA = *existingLocalCA
@@ -520,6 +520,7 @@ func (r *ControlPlaneReconciler) createRouterSecrets(namespace string, ms *micro
 		r.log.Info(fmt.Sprintf("Generating site server certificate for Controlplane %s with address %s", r.cp.Name, address))
 		siteSecret := util.GenerateSecret(SiteServerSecret, siteSecretSubject, siteSecretAddress, 0, &siteCA)
 		siteSecret.Namespace = namespace
+		siteSecret.Labels = routerLabels
 		ms.secrets = append(ms.secrets, siteSecret)
 	} else {
 		ms.secrets = append(ms.secrets, *existingSiteServer)
@@ -529,6 +530,7 @@ func (r *ControlPlaneReconciler) createRouterSecrets(namespace string, ms *micro
 		r.log.Info(fmt.Sprintf("Generating local server certificate for Controlplane %s with address %s", r.cp.Name, address))
 		localSecret := util.GenerateSecret(LocalServerSecret, localSecretSubject, localSecretAddress, 0, &localCA)
 		localSecret.Namespace = namespace
+		localSecret.Labels = routerLabels
 		ms.secrets = append(ms.secrets, localSecret)
 	} else {
 		ms.secrets = append(ms.secrets, *existingLocalServer)

--- a/controllers/controlplanes/resources.go
+++ b/controllers/controlplanes/resources.go
@@ -23,20 +23,57 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
-func newServices(namespace string, ms *microservice) (svcs []*corev1.Service) {
+const (
+	standardLabelManagedBy = "iofog-operator"
+	standardLabelName      = "pot"
+)
+
+// getStandardLabels returns Kubernetes and Datasance standard labels for operator-created resources.
+func getStandardLabels(component, instanceName string) map[string]string {
+	return map[string]string{
+		"app.kubernetes.io/name":       standardLabelName,
+		"app.kubernetes.io/instance":   instanceName,
+		"app.kubernetes.io/component":  component,
+		"app.kubernetes.io/managed-by": standardLabelManagedBy,
+		"datasance.com/component":      component,
+	}
+}
+
+// mergeLabels merges existing labels with standard labels; standard labels take precedence.
+func mergeLabels(standard, existing map[string]string) map[string]string {
+	merged := make(map[string]string)
+	for k, v := range existing {
+		merged[k] = v
+	}
+	for k, v := range standard {
+		merged[k] = v
+	}
+	return merged
+}
+
+// getComponentFromMicroservice returns the component name for labeling ("controller" or "router").
+func getComponentFromMicroservice(ms *microservice) string {
+	if ms.name == "controller" {
+		return "controller"
+	}
+	return "router"
+}
+
+func newServices(namespace, instanceName string, ms *microservice) (svcs []*corev1.Service) {
+	labels := mergeLabels(getStandardLabels(getComponentFromMicroservice(ms), instanceName), ms.labels)
 	for _, msvcSvc := range ms.services {
 		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        msvcSvc.name,
 				Namespace:   namespace,
-				Labels:      ms.labels,
+				Labels:      labels,
 				Annotations: msvcSvc.serviceAnnotations,
 			},
 			Spec: corev1.ServiceSpec{
 				Type:                  corev1.ServiceType(msvcSvc.serviceType),
 				ExternalTrafficPolicy: corev1.ServiceExternalTrafficPolicyType(msvcSvc.trafficPolicy),
 				LoadBalancerIP:        msvcSvc.loadBalancerAddr,
-				Selector:              ms.labels,
+				Selector:              labels,
 			},
 		}
 		// Add ports
@@ -57,13 +94,15 @@ type controllerIngressConfig struct {
 	secretName       string
 }
 
-func newControllerIngress(namespace string, cfg *controllerIngressConfig) *networkingv1.Ingress {
+func newControllerIngress(namespace, instanceName string, cfg *controllerIngressConfig) *networkingv1.Ingress {
 	pathType := networkingv1.PathTypePrefix
+	labels := getStandardLabels("controller", instanceName)
 
 	return &networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "pot-controller",
 			Namespace:   namespace,
+			Labels:      labels,
 			Annotations: cfg.annotations,
 		},
 		Spec: networkingv1.IngressSpec{
@@ -113,7 +152,7 @@ func newControllerIngress(namespace string, cfg *controllerIngressConfig) *netwo
 	}
 }
 
-func newDeployment(namespace string, ms *microservice) *appsv1.Deployment {
+func newDeployment(namespace, instanceName string, ms *microservice) *appsv1.Deployment {
 	maxUnavailable := intstr.FromInt(0)
 	maxSurge := intstr.FromInt(1)
 	strategy := appsv1.DeploymentStrategy{
@@ -130,22 +169,24 @@ func newDeployment(namespace string, ms *microservice) *appsv1.Deployment {
 		}
 	}
 
+	labels := mergeLabels(getStandardLabels(getComponentFromMicroservice(ms), instanceName), ms.labels)
+
 	dep := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ms.name,
 			Namespace: namespace,
-			Labels:    ms.labels,
+			Labels:    labels,
 		},
 		Spec: appsv1.DeploymentSpec{
 			MinReadySeconds: ms.availableDelay,
 			Replicas:        &ms.replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: ms.labels,
+				MatchLabels: labels,
 			},
 			Strategy: strategy,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: ms.labels,
+					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
 					ServiceAccountName: ms.name,
@@ -199,20 +240,24 @@ func newDeployment(namespace string, ms *microservice) *appsv1.Deployment {
 	return dep
 }
 
-func newServiceAccount(namespace string, ms *microservice) *corev1.ServiceAccount {
+func newServiceAccount(namespace, instanceName string, ms *microservice) *corev1.ServiceAccount {
+	labels := mergeLabels(getStandardLabels(getComponentFromMicroservice(ms), instanceName), ms.labels)
 	return &corev1.ServiceAccount{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ms.name,
 			Namespace: namespace,
+			Labels:    labels,
 		},
 	}
 }
 
-func newRoleBinding(namespace string, ms *microservice) *rbacv1.RoleBinding {
+func newRoleBinding(namespace, instanceName string, ms *microservice) *rbacv1.RoleBinding {
+	labels := mergeLabels(getStandardLabels(getComponentFromMicroservice(ms), instanceName), ms.labels)
 	return &rbacv1.RoleBinding{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ms.name,
 			Namespace: namespace,
+			Labels:    labels,
 		},
 		Subjects: []rbacv1.Subject{
 			{
@@ -228,21 +273,25 @@ func newRoleBinding(namespace string, ms *microservice) *rbacv1.RoleBinding {
 	}
 }
 
-func newRole(namespace string, ms *microservice) *rbacv1.Role {
+func newRole(namespace, instanceName string, ms *microservice) *rbacv1.Role {
+	labels := mergeLabels(getStandardLabels(getComponentFromMicroservice(ms), instanceName), ms.labels)
 	return &rbacv1.Role{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ms.name,
 			Namespace: namespace,
+			Labels:    labels,
 		},
 		Rules: ms.rbacRules,
 	}
 }
 
-func newRouterConfigMap(namespace string) *corev1.ConfigMap {
+func newRouterConfigMap(namespace, instanceName string) *corev1.ConfigMap {
+	labels := getStandardLabels("router", instanceName)
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "pot-router",
 			Namespace: namespace,
+			Labels:    labels,
 		},
 		Data: map[string]string{
 			"skrouterd.json": router.GetConfig(namespace),

--- a/controllers/controlplanes/router/config.go
+++ b/controllers/controlplanes/router/config.go
@@ -48,6 +48,13 @@ const rawRouterConfig = `
     [
         "sslProfile",
         {
+            "name": "system-default",
+            "certFile": "/etc/pki/tls/certs/ca-bundle.crt"
+        }
+    ],
+    [
+        "sslProfile",
+        {
             "name": "pot-router-site-server",
             "certFile": "/etc/skupper-router-certs/pot-router-site-server/tls.crt",
             "privateKeyFile": "/etc/skupper-router-certs/pot-router-site-server/tls.key",

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/datasance/iofog-operator/v3
 go 1.23.0
 
 require (
-	github.com/datasance/iofog-go-sdk/v3 v3.5.2
+	github.com/datasance/iofog-go-sdk/v3 v3.6.0
 	github.com/go-logr/logr v1.4.2
 	golang.org/x/oauth2 v0.23.0
 	k8s.io/api v0.32.0
@@ -66,6 +66,7 @@ require (
 )
 
 retract (
+	v3.5.3 // Published accidentally.
 	v3.4.15 // retract as db migration scripts fixed.
 	v3.4.14 // retract as db migration scripts fixed.
 	v3.4.5 // Published accidentally.
@@ -84,5 +85,4 @@ retract (
 	v3.2.3 // Published accidentally.
 	v3.2.2 // Published accidentally.
 	v3.2.1 // Published accidentally.
-	v3.5.3 // Published accidentally.
 )

--- a/go.sum
+++ b/go.sum
@@ -3,8 +3,8 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/datasance/iofog-go-sdk/v3 v3.5.2 h1:URjli6rEJl1leGSujYD1lZdyDSy8scM+4DA4kCyPpPM=
-github.com/datasance/iofog-go-sdk/v3 v3.5.2/go.mod h1:Gx/T77nGu3QvC93c96IDMEHJ2cdqZA84icl7R87ds84=
+github.com/datasance/iofog-go-sdk/v3 v3.6.0 h1:HQ7AK3FrNDirgL8Kp5FPsfmRtdTImu+BXV36bZPGFqs=
+github.com/datasance/iofog-go-sdk/v3 v3.6.0/go.mod h1:Gx/T77nGu3QvC93c96IDMEHJ2cdqZA84icl7R87ds84=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=

--- a/internal/util/images.go
+++ b/internal/util/images.go
@@ -17,23 +17,17 @@ import "fmt"
 
 // These values are set by the linker, e.g. "LDFLAGS += -X $(PREFIX).controllerTag=v3.0.0-beta1".
 var (
-	repo             = "undefined" //nolint:gochecknoglobals
-	controllerTag    = "undefined" //nolint:gochecknoglobals
-	routerTag        = "undefined" //nolint:gochecknoglobals
-	routerAdaptorTag = "undefined" //nolint:gochecknoglobals
+	repo          = "undefined" //nolint:gochecknoglobals
+	controllerTag = "undefined" //nolint:gochecknoglobals
+	routerTag     = "undefined" //nolint:gochecknoglobals
 )
 
 const (
-	controllerImage    = "controller"
-	routerImage        = "router"
-	routerAdaptorImage = "router-adaptor"
+	controllerImage = "controller"
+	routerImage     = "router"
 )
 
 func GetControllerImage() string {
 	return fmt.Sprintf("%s/%s:%s", repo, controllerImage, controllerTag)
 }
 func GetRouterImage() string { return fmt.Sprintf("%s/%s:%s", repo, routerImage, routerTag) }
-
-func GetRouterAdaptorImage() string {
-	return fmt.Sprintf("%s/%s:%s", repo, routerAdaptorImage, routerAdaptorTag)
-}


### PR DESCRIPTION
…aptor component (controller/router images and related API, CRD, bundle, and config references). Extend the Applications CRD with new microservice options (healthCheck, execStatus, schedule, cpuSetCpus, hostNetworkMode, isPrivileged, memoryLimit, platform fields, GPS/edgeGuard settings) and refactor controlplane microservice handling and router config accordingly.